### PR TITLE
PERF: inline small functions

### DIFF
--- a/BirthDeathCython.pyx
+++ b/BirthDeathCython.pyx
@@ -280,13 +280,13 @@ cdef class BirthDeathModel:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef void HapPopRate(self, Py_ssize_t popId, Py_ssize_t haplotype):
+    cdef inline void HapPopRate(self, Py_ssize_t popId, Py_ssize_t haplotype):
         self.hapPopRate[popId, haplotype] = self.tEventHapPopRate[popId, haplotype]*self.liveBranches[popId, haplotype]
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef double BirthRate(self, Py_ssize_t popId, Py_ssize_t haplotype):
+    cdef inline double BirthRate(self, Py_ssize_t popId, Py_ssize_t haplotype):
         return self.bRate[haplotype]*self.pm.susceptible[popId]/self.pm.sizes[popId]*self.pm.contactDensity[popId]
 
     @cython.boundscheck(False)
@@ -391,8 +391,7 @@ cdef class BirthDeathModel:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void SampleTime(self):
-        #cdef double tau = - log(np.random.rand()) / self.totalRate
+    cdef inline void SampleTime(self):
         cdef double tau = - log(self.rndm.uniform()) / self.totalRate
         self.currentTime += tau
 


### PR DESCRIPTION
which were visible in the yep/pprof profile.

With this, the profile's like this:

```
$ python -m yep -- ViralSim.py example/example.rt -it 4000000 -pm example/example.pp example/example.mg
Total number of iterations:  4000001
Number of lineages of each hyplotype: 16  16  16  16  
popNum:  4
dim:  2
hapNum:  16
totalRate:  54933167.412552014
rn:  0.038244609925287
susceptible:  30164669
lbCounter:  1295771
Current time:  0.7314947843028698
Tree size:  266893
Number of sampled elements:  133447
0.7787821292877197
0.8148717880249023
_________________________________
PROFILE: interrupts/evictions/bytes = 191/120/37312
(mc_lib_2) br@duneyrr:~/sweethome/proj/ViralSim$ google-pprof --text --lines `which python` ViralSim.py.prof |more
Using local file /home/br/virtualenvs/mc_lib_2/bin/python.
Using local file ViralSim.py.prof.
Total: 191 samples
      29  15.2%  15.2%       29  15.2% __sched_yield ??:0
       9   4.7%  19.9%        9   4.7% PyLong_FromSsize_t ??:0
       9   4.7%  24.6%        9   4.7% PySet_Contains ??:0
       8   4.2%  28.8%        8   4.2% __pyx_f_16BirthDeathCython_15BirthDeathModel_HapPopRate (inline) /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:7673
       7   3.7%  32.5%        7   3.7% __pyx_f_16BirthDeathCython_15BirthDeathModel_GenerateEvent (inline) /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:31649
       6   3.1%  35.6%        6   3.1% __pyx_pw_16BirthDeathCython_5Event_1__init__ /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:3363
       5   2.6%  38.2%        5   2.6% __pyx_f_16BirthDeathCython_15BirthDeathModel_SampleTime (inline) /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:8521
       5   2.6%  40.8%        5   2.6% _init ??:0
       4   2.1%  42.9%        4   2.1% __pyx_f_16BirthDeathCython_15BirthDeathModel_Birth /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:8707
       4   2.1%  45.0%        4   2.1% __pyx_f_16BirthDeathCython_15BirthDeathModel_Birth /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:8718
       4   2.1%  47.1%        4   2.1% f64xsubf128 ??:0
       4   2.1%  49.2%        4   2.1% std::abs (inline) /usr/include/c++/9/bits/std_abs.h:56
       3   1.6%  50.8%        3   1.6% __pyx_f_16BirthDeathCython_15BirthDeathModel_Birth (inline) /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:7715
       3   1.6%  52.4%        3   1.6% __pyx_f_16BirthDeathCython_15BirthDeathModel_Birth /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:8543
       3   1.6%  53.9%        3   1.6% __pyx_f_16BirthDeathCython_15BirthDeathModel_Birth /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:8617
       3   1.6%  55.5%        3   1.6% __pyx_f_16BirthDeathCython_15BirthDeathModel_Death /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:8934
       3   1.6%  57.1%        3   1.6% __pyx_f_16BirthDeathCython_15BirthDeathModel_GenerateEvent (inline) /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:31626
       3   1.6%  58.6%        3   1.6% __pyx_f_16BirthDeathCython_fastChoose1 [clone .isra.0] /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:6085
       3   1.6%  60.2%        3   1.6% __pyx_f_16BirthDeathCython_fastChoose1 [clone .isra.0] /home/br/sweethome/proj/ViralSim/BirthDeathCython.cpp:6107

```